### PR TITLE
Adding ability for tokens to be parsed from globus.cfg

### DIFF
--- a/sregistry/main/globus/__init__.py
+++ b/sregistry/main/globus/__init__.py
@@ -30,7 +30,7 @@ import os
 
 from .utils import (
     create_endpoint_cache,
-    create_endpoint_folder,    
+    create_endpoint_folder,
     get_endpoints,
     get_endpoint_path,
     init_transfer_client,

--- a/sregistry/main/globus/__init__.py
+++ b/sregistry/main/globus/__init__.py
@@ -30,10 +30,11 @@ import os
 
 from .utils import (
     create_endpoint_cache,
-    create_endpoint_folder,
+    create_endpoint_folder,    
     get_endpoints,
     get_endpoint_path,
     init_transfer_client,
+    load_config_token,
     parse_endpoint_name
 )
 
@@ -76,11 +77,20 @@ class Client(ApiConnection):
     def _load_secrets(self):
         '''load the secrets credentials file with the Globus OAuthTokenResponse
         '''
+        # This file may not exist, will return None
+        globus_auth = os.path.expanduser("~/.globus.cfg")
 
-        # Second priority: load from cache
+        # If the client has already created a association, load it (or None)
+        auth = self._load_config_token(globus_auth, 'auth')
+        transfer = self._load_config_token(globus_auth, token_type = 'transfer',
+                   scope = "urn:globus:auth:scope:transfer.api.globus.org:all",
+                   resource_server = "transfer.api.globus.org")
        
-        self.auth = self._get_and_update_setting('GLOBUS_AUTH_RESPONSE')
-        self.transfer = self._get_and_update_setting('GLOBUS_TRANSFER_RESPONSE')
+        # First priority: load from cache, use loaded above as default
+
+        self.auth = self._get_and_update_setting('GLOBUS_AUTH_RESPONSE', auth)
+        self.transfer = self._get_and_update_setting('GLOBUS_TRANSFER_RESPONSE',
+                                                     transfer)
 
 
     # Runtime Calls
@@ -125,6 +135,7 @@ class Client(ApiConnection):
 
 # Transfer
 Client._init_transfer_client = init_transfer_client
+Client._load_config_token = load_config_token
 
 # Endpoints
 Client._create_endpoint_cache = create_endpoint_cache

--- a/sregistry/main/globus/utils.py
+++ b/sregistry/main/globus/utils.py
@@ -169,14 +169,17 @@ def load_config_token(self, auth_file,
             if line.startswith(token_type):
 
                 # If we haven't found anything yet, intialize dictionary
+
                 if not config_token: 
                     config_token = {"token_type": "Bearer"}
 
                 # Split based on equals, and remove white space
+
                 var, value = [x.strip() for x in line.split('=')]
                 var = var.replace('%s_' %token_type, '')
 
                 # Expiration key is different between config and API
+
                 if 'expires' in var:
                     config_token['expires_at_seconds'] = int(value)
                 else:

--- a/sregistry/main/globus/utils.py
+++ b/sregistry/main/globus/utils.py
@@ -21,7 +21,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from sregistry.logger import bot
 from sregistry.utils import read_file
-import pickle
+import re
 import os
 import requests
 import globus_sdk
@@ -93,7 +93,7 @@ def get_endpoint_path(self, endpoint_id):
     '''
     config = os.path.expanduser("~/.globusonline/lta/config-paths")
     if not os.path.exists(config):
-        bot.error('%s not found for a local Globus endpoint.')
+        bot.error('%s not found for a local Globus endpoint.' %config)
         sys.exit(1)
 
     path = None
@@ -133,6 +133,56 @@ def init_transfer_client(self):
 
     self.transfer_client = globus_sdk.TransferClient(authorizer=authorizer)
 
+
+def load_config_token(self, auth_file, 
+                      token_type='auth',
+                      scope = "profile openid email",
+                      resource_server = "auth.globus.org"):
+    '''if the user has authenticated with globus and has a globus.cfg file.
+       we don't need to repeat the handshake to get an access and refresh
+       token. This function will load the variables from file and save
+       them in the .sregistry cache.
+
+       Parameters
+       ==========
+       auth_file: the full path to globus.cfg with [cli] section
+       token_type: one of access (default) or transfer
+       scope: default scope type
+
+       Returns
+       =======
+       data structure with fields corresponding to the token type, for
+       adding to the .sregistry file. For example, a field like:
+ 
+           transfer_access_token = xxxx
+
+       given token_type transfer will return as  {'access_token': 'xxxx' }
+       
+    '''
+    config_token = None
+
+    if os.path.exists(auth_file):    
+
+        lines = [x.strip() for x in read_file(auth_file)]
+        for line in lines:
+
+            if line.startswith(token_type):
+
+                # If we haven't found anything yet, intialize dictionary
+                if not config_token: 
+                    config_token = {"token_type": "Bearer"}
+
+                # Split based on equals, and remove white space
+                var, value = [x.strip() for x in line.split('=')]
+                var = var.replace('%s_' %token_type, '')
+
+                # Expiration key is different between config and API
+                if 'expires' in var:
+                    config_token['expires_at_seconds'] = int(value)
+                else:
+                    config_token[var] = value
+
+    return config_token
 
 
 def get_endpoints(self, query=None):


### PR DESCRIPTION
This PR will make it so that if a client has already gotten an auth/refresh token via the globus.cfg in `$HOME`, we use that instead of asking for another one. This solves the problem described best as:

> Welcome to the Department of Redundancy Department!